### PR TITLE
Fix paused sensor and added queued sensor

### DIFF
--- a/custom_components/qbittorrent_alt/coordinator.py
+++ b/custom_components/qbittorrent_alt/coordinator.py
@@ -55,6 +55,7 @@ class QBittorrentDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             downloading = 0
             seeding = 0
             paused = 0
+            queued = 0
             stalled = 0
             uploading = 0
             longest_eta = 0
@@ -69,8 +70,10 @@ class QBittorrentDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     seeding += 1
                 if torrent["state"] == "uploading":
                     uploading += 1
-                if torrent["state"] == "pausedUP" or torrent["state"] == "pausedDL":
+                if torrent["state"] == "stoppedDL":
                     paused += 1
+                if torrent["state"] == "queuedDL":
+                    queued += 1
                 if torrent["state"] == "stalledDL":
                     stalled += 1
                 if torrent["eta"] != 8640000 and torrent["eta"] > longest_eta:
@@ -82,6 +85,7 @@ class QBittorrentDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 "seeding": seeding,
                 "uploading": uploading,
                 "paused": paused,
+                "queued": queued,
                 "stalled": stalled,
                 "total": len(main_data.torrents),
                 "longest_eta": longest_eta,

--- a/custom_components/qbittorrent_alt/helpers.py
+++ b/custom_components/qbittorrent_alt/helpers.py
@@ -47,7 +47,7 @@ def get_qbittorrent_state(coordinator: QBittorrentDataCoordinator) -> str:
     upload = coordinator.data["sync"].server_state["up_info_speed"]
 
     if upload > 0 and download > 0:
-        return "up_down"
+        return "downloading and seeding"
     if upload > 0 and download == 0:
         return "seeding"
     if upload == 0 and download > 0:

--- a/custom_components/qbittorrent_alt/icons.json
+++ b/custom_components/qbittorrent_alt/icons.json
@@ -68,6 +68,9 @@
             "paused": {
                 "default": "mdi:pause"
             },
+            "queued": {
+                "default": "mdi:tray-full"
+            },
             "stalled": {
                 "default": "mdi:download-off"
             },

--- a/custom_components/qbittorrent_alt/sensor.py
+++ b/custom_components/qbittorrent_alt/sensor.py
@@ -44,7 +44,7 @@ SENSOR_TYPES: tuple[QBittorrentSensorEntityDescription, ...] = (
         name="Status",
         device_class=SensorDeviceClass.ENUM,
         value_fn=get_qbittorrent_state,
-        options=["up_down", "seeding", "downloading", STATE_IDLE],
+        options=["downloading and seeding", "seeding", "downloading", STATE_IDLE],
     ),
     QBittorrentSensorEntityDescription(
         key="download_speed",
@@ -180,6 +180,14 @@ SENSOR_TYPES: tuple[QBittorrentSensorEntityDescription, ...] = (
         icon="mdi:pause",
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda coordinator: coordinator.data["paused"],
+    ),
+    ),
+    QBittorrentSensorEntityDescription(
+        key="queued",
+        name="Queued",
+        icon="mdi:tray-full",
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda coordinator: coordinator.data["queued"],
     ),
     QBittorrentSensorEntityDescription(
         key="stalled",

--- a/custom_components/qbittorrent_alt/sensor.py
+++ b/custom_components/qbittorrent_alt/sensor.py
@@ -181,7 +181,6 @@ SENSOR_TYPES: tuple[QBittorrentSensorEntityDescription, ...] = (
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda coordinator: coordinator.data["paused"],
     ),
-    ),
     QBittorrentSensorEntityDescription(
         key="queued",
         name="Queued",


### PR DESCRIPTION
In qBittorrent v5.0.0, "pausedDL" has been renamed to "stoppedDL" - this change is needed to fix the paused sensor;

A new sensor has been added to display queued downloads;

The status "up_down" has been renamed to "downloading and seeding";